### PR TITLE
Add new function that takes pointer and a callback

### DIFF
--- a/include/ddynamic_reconfigure/ddynamic_reconfigure.h
+++ b/include/ddynamic_reconfigure/ddynamic_reconfigure.h
@@ -60,6 +60,8 @@ public:
    * @brief registerVariable register a variable to be modified via the
    * dynamic_reconfigure API. When a change is made, it will be reflected in the
    * variable directly
+   * @deprecated In the future this method will be merged with the registerVariable
+   * that takes a pointer and a callback, but with the callback being optional
    */
   template<typename T>
   void registerVariable(const std::string &name, T *variable,
@@ -72,11 +74,30 @@ public:
                             std::map<std::string, T> enum_dict = {},
                             const std::string &enum_description = "",
                             const std::string &group = "Default");
+  /**
+   * @brief registerVariable like the functions above, but with a callback to be called when the
+   * variable is changed from the dynamic_reconfigure API.
+   */
+  template <typename T>
+  void registerVariable(const std::string &name, T *variable,
+                        const boost::function<void(T value)> &callback,
+                        const std::string &description = "", T min = getMin<T>(), T max = getMax<T>(),
+                        const std::string &group = "Default");
+
+  template <typename T>
+  void registerEnumVariable(const std::string &name, T *variable,
+                            const boost::function<void(T)> &callback,
+                            const std::string &description,
+                            std::map<std::string, T> enum_dict = {},
+                            const std::string &enum_description = "",
+                            const std::string &group = "Default");
 
   /**
    * @brief registerVariable register a variable to be modified via the
    * dynamic_reconfigure API. When a change is made, the callback will be called with the
-   * new value
+   * new value. The variable itself is not modified when registered using this method.
+   * This method is useful for "dynamic reconfigure variables" that don't have a
+   * direct equivalent in the C++ code, such as vector.size().
    */
   template <typename T>
   void registerVariable(const std::string &name, T current_value,

--- a/include/ddynamic_reconfigure/registered_param.h
+++ b/include/ddynamic_reconfigure/registered_param.h
@@ -34,6 +34,7 @@
 #include <map>
 #include <sstream>
 #include <type_traits>
+#include <boost/function.hpp>
 #include <dynamic_reconfigure/ParamDescription.h>
 namespace ddynamic_reconfigure {
    
@@ -164,11 +165,12 @@ class PointerRegisteredParam : public RegisteredParam<T>
 {
 public:
   PointerRegisteredParam(const std::string &name, const std::string &description,
-                         T min_value, T max_value, T *variable, 
+                         T min_value, T max_value, T *variable,
+                         boost::function<void(T value)> callback = {},
                          std::map<std::string, T> enum_dictionary = {},
                          const std::string &enum_description = "", const std::string &group = "")
     : RegisteredParam<T>(name, description, min_value, max_value, enum_dictionary, enum_description, group)
-    , variable_(variable)
+    , variable_(variable), callback_(callback)
   {
   }
 
@@ -179,10 +181,13 @@ public:
   void updateValue(T new_value) override
   {
     *variable_ = new_value;
+    if (!callback_.empty())
+      callback_(new_value);
   }
 
 protected:
   T *variable_;
+  boost::function<void(T value)> callback_;
 };
 
 template <typename T>


### PR DESCRIPTION
Yet another implementation for https://github.com/pal-robotics/ddynamic_reconfigure/pull/9

The goal in the future will be to add the callback to the default method that takes a pointer as input. But for keeping backwards compatiblity now 