### PR TITLE
use the current c++, c++0x doesn't build properly on newer systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 catkin_package(


### PR DESCRIPTION
This probably should only go into a new noetic-devel branch though maybe it works fine on melodic?

I was getting this error on a c++17 system, removing the c++0x fixes it:

```
/usr/include/log4cxx/boost-std-configuration.h:10:18: error: ‘shared_mutex’ in namespace ‘std’ does not name a type
   10 |     typedef std::shared_mutex shared_mutex;
      |                  ^~~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:10:13: note: ‘std::shared_mutex’ is only available from C++17 onwards
   10 |     typedef std::shared_mutex shared_mutex;
      |             ^~~
/usr/include/log4cxx/boost-std-configuration.h:12:30: error: ‘shared_lock’ in namespace ‘std’ does not name a template type
   12 |     using shared_lock = std::shared_lock<T>;
      |                              ^~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:12:25: note: ‘std::shared_lock’ is only available from C++14 onwards
   12 |     using shared_lock = std::shared_lock<T>;
      |                         ^~~
make[2]: *** [CMakeFiles/ddynamic_reconfigure.dir/build.make:76: CMakeFiles/ddynamic_reconfigure.dir/src/ddynamic_reconfigure.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:583: CMakeFiles/ddynamic_reconfigure.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```