### PR TITLE
Add Pre-Update Callback Function Trigger to Parameter Update Process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 catkin_package(

--- a/include/ddynamic_reconfigure/ddynamic_reconfigure.h
+++ b/include/ddynamic_reconfigure/ddynamic_reconfigure.h
@@ -131,18 +131,34 @@ public:
   typedef boost::function<void()> UserCallbackType;
 
   /**
-   * @brief setUserCallback An optional callback that will be called whenever a value is
+   * @brief setPreUpdateCallback An optional callback that will be called right before any value is
    * changed
    */
-  virtual void setUserCallback(const UserCallbackType &callback);
+  virtual void setPreUpdateCallback(const UserCallbackType &callback);
 
-  virtual void clearUserCallback();
+  virtual void clearPreUpdateCallback();
 
+  /**
+   * @brief setPostUpdateCallback An optional callback that will be called right after any value is
+   * changed.
+   */
+  virtual void setPostUpdateCallback(const UserCallbackType &callback);
+
+  virtual void clearPostUpdateCallback();
 
   /**
    * Deprecated functions. For backwards compatibility, cannot be a template for legacy
    * reasons
    */
+
+  /**
+   * @brief setUserCallback An optional callback that will be called whenever a value is
+   * changed. This is equivalent to the setPostUpdateCallback.
+   */
+  virtual void setUserCallback(const UserCallbackType &callback);
+
+  virtual void clearUserCallback();
+
   virtual void RegisterVariable(double *variable, std::string id, double min = -100,
                                 double max = 100);
 
@@ -192,7 +208,8 @@ protected:
   std::vector<std::unique_ptr<RegisteredParam<std::string>>> registered_string_;
   std::vector<std::string> config_groups_;
 
-  UserCallbackType user_callback_;
+  UserCallbackType pre_update_callback_;
+  UserCallbackType post_update_callback_;
 
   ros::Timer pub_config_timer_;
   dynamic_reconfigure::Config last_config_;

--- a/src/ddynamic_reconfigure.cpp
+++ b/src/ddynamic_reconfigure.cpp
@@ -186,6 +186,22 @@ bool DDynamicReconfigure::setConfigCallback(dynamic_reconfigure::Reconfigure::Re
 {
   ROS_DEBUG_STREAM("Called config callback of ddynamic_reconfigure");
 
+  if (pre_update_callback_)
+  {
+    try
+    {
+      pre_update_callback_();
+    }
+    catch (std::exception &e)
+    {
+      ROS_WARN("Reconfigure pre update callback failed with exception %s: ", e.what());
+    }
+    catch (...)
+    {
+      ROS_WARN("Reconfigure pre update callback failed with unprintable exception.");
+    }
+  }
+
   updated_config_ = req.config;
   if (auto_update_)
   {
@@ -237,19 +253,19 @@ bool DDynamicReconfigure::setConfigCallback(dynamic_reconfigure::Reconfigure::Re
      */
   // std::cerr<<req.config<<std::endl;
 
-  if (user_callback_)
+  if (post_update_callback_)
   {
     try
     {
-      user_callback_();
+      post_update_callback_();
     }
     catch (std::exception &e)
     {
-      ROS_WARN("Reconfigure callback failed with exception %s: ", e.what());
+      ROS_WARN("Reconfigure post update callback failed with exception %s: ", e.what());
     }
     catch (...)
     {
-      ROS_WARN("Reconfigure callback failed with unprintable exception.");
+      ROS_WARN("Reconfigure post update callback failed with unprintable exception.");
     }
   }
 
@@ -295,12 +311,32 @@ void DDynamicReconfigure::updateConfigData(const dynamic_reconfigure::Config &co
 
 void DDynamicReconfigure::setUserCallback(const DDynamicReconfigure::UserCallbackType &callback)
 {
-  user_callback_ = callback;
+  setPostUpdateCallback(callback);
 }
 
 void DDynamicReconfigure::clearUserCallback()
 {
-  user_callback_.clear();
+  clearPostUpdateCallback();
+}
+
+void DDynamicReconfigure::setPreUpdateCallback(const DDynamicReconfigure::UserCallbackType &callback)
+{
+  pre_update_callback_ = callback;
+}
+
+void DDynamicReconfigure::clearPreUpdateCallback()
+{
+  pre_update_callback_.clear();
+}
+
+void DDynamicReconfigure::setPostUpdateCallback(const DDynamicReconfigure::UserCallbackType &callback)
+{
+  post_update_callback_ = callback;
+}
+
+void DDynamicReconfigure::clearPostUpdateCallback()
+{
+  post_update_callback_.clear();
 }
 
 void DDynamicReconfigure::RegisterVariable(double *variable, std::string id, double min, double max)

--- a/test/test_ddynamic_reconfigure.cpp
+++ b/test/test_ddynamic_reconfigure.cpp
@@ -17,7 +17,8 @@ public:
   MockClass() : double_param_(0.0), int_param_(0), bool_param_(false)
   {
   }
-  MOCK_METHOD0(userCallback, void());
+  MOCK_METHOD0(preUpdateCallback, void());
+  MOCK_METHOD0(postUpdateCallback, void());
 
   MOCK_METHOD1(strCallback, void(std::string));
 
@@ -129,12 +130,14 @@ TEST_F(DDynamicReconfigureTest, globalCallbackTest)
   dd.RegisterVariable(&mock.int_param_, "int_param", 0, 100);
   dd.RegisterVariable(&mock.bool_param_, "bool_param");
   dd.RegisterVariable(&mock.double_param_, "double_param", -50, 50);
-  dd.setUserCallback(boost::bind(&MockClass::userCallback, &mock));
+  dd.setPreUpdateCallback(boost::bind(&MockClass::preUpdateCallback, &mock));
+  dd.setPostUpdateCallback(boost::bind(&MockClass::postUpdateCallback, &mock));
   dd.PublishServicesTopics();
   ros::AsyncSpinner spinner(1);
   spinner.start();
 
-  EXPECT_CALL(mock, userCallback()).Times(Exactly(1));
+  EXPECT_CALL(mock, preUpdateCallback()).Times(Exactly(1));
+  EXPECT_CALL(mock, postUpdateCallback()).Times(Exactly(1));
 
   dynamic_reconfigure::Reconfigure srv;
   dynamic_reconfigure::IntParameter int_param;


### PR DESCRIPTION
Hi! I want to propose a new feature for this great library!

This pull request adds a trigger point for a callback function right before any parameter value is updated.
This enhancement complements the existing functionality where a callback can be called after the parameter update.

## Motivation
Some camera devices must stop streaming before changing settings and then restart it after the update.
This pre-update callback will provide users with the flexibility to programmatically handle such scenarios.

## Changes
- Added `setPreUpdateCallback` / `clearPreUpdateCallback`
- Added `setPostUpdateCallback` (which is identical to the original `setUserCallback`)

## Backward Compatibility
This change is fully backward compatible. (The original methods are kept as-is)
The new callback is optional and does not affect the existing workflow if not used.
