### PR TITLE
Advertise services/topics only if they are not advertised yet

### DIFF
--- a/src/ddynamic_reconfigure.cpp
+++ b/src/ddynamic_reconfigure.cpp
@@ -19,6 +19,10 @@ DDynamicReconfigure::~DDynamicReconfigure()
 
 void DDynamicReconfigure::publishServicesTopics()
 {
+  if (advertised_)
+  {
+    return;
+  }
   descr_pub_ = node_handle_.advertise<dynamic_reconfigure::ConfigDescription>(
       "parameter_descriptions", 1, true);
   const dynamic_reconfigure::ConfigDescription config_description = generateConfigDescription();


### PR DESCRIPTION
This is a simple fix for the method `DDynamicReconfigure::publishServicesTopics` that prevents to advertise services/topics more than once which causes errors.