### PR TITLE
Support exception in callback

### DIFF
--- a/include/ddynamic_reconfigure/ddynamic_reconfigure.h
+++ b/include/ddynamic_reconfigure/ddynamic_reconfigure.h
@@ -32,6 +32,7 @@
 #define _DDYNAMIC_RECONFIGURE_
 
 #include <dynamic_reconfigure/server.h>
+#include <ddynamic_reconfigure/exception.h>
 #include <ddynamic_reconfigure/registered_param.h>
 #include <ddynamic_reconfigure/ddynamic_reconfigure_utils.h>
 #include <ros/ros.h>
@@ -186,6 +187,9 @@ protected:
                                  dynamic_reconfigure::Reconfigure::Response &rsp);
 
   virtual void updateConfigData(const dynamic_reconfigure::Config &config);
+
+  virtual void callPreUpdateCallback();
+  virtual void callPostUpdateCallback();
 
   /**
    * @brief setUserCallback Set a function to be called when parameters have changed

--- a/include/ddynamic_reconfigure/exception.h
+++ b/include/ddynamic_reconfigure/exception.h
@@ -27,93 +27,19 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef DDYNAMIC_RECONFIGURE_UTILS_H
-#define DDYNAMIC_RECONFIGURE_UTILS_H
-#include <string>
-#include <limits>
-#include <vector>
+#ifndef EXCEPTION_H
+#define EXCEPTION_H
 
-template <typename T>
-inline T getMin()
+#include <stdexcept>
+
+namespace ddynamic_reconfigure
 {
-  return std::numeric_limits<T>::min();
-}
-
-template <>
-inline bool getMin()
-{
-  return false;
-}
-
-template <>
-inline std::string getMin<std::string>()
-{
-  return "";
-}
-
-template <typename T>
-inline T getMax()
-{
-  return std::numeric_limits<T>::max();
-}
-
-template <>
-inline bool getMax()
-{
-  return true;
-}
-
-template <>
-inline std::string getMax()
-{
-  return "";
-}
-
-
-template <class T, class V>
-bool assignValue(const std::vector<T> &v, const std::string &name, const V &value)
-{
-  for (unsigned int i = 0; i < v.size(); ++i)
+  class CallbackException : public std::runtime_error
   {
-    if (v[i]->name_ == name)
-    {
-      v[i]->updateValue(value);
-      return true;
-    }
-  }
-  return false;
+   public:
+    explicit CallbackException(const std::string& msg = "") : std::runtime_error(msg) {}
+    ~CallbackException() {}
+  };
 }
 
-template <typename T>
-void attemptGetParam(ros::NodeHandle &nh, const std::string &name, T &param, const T default_value)
-{
-  if (nh.hasParam(name))
-  {
-    nh.param<T>(name, param, default_value);
-  }
-}
-
-template <typename T>
-std::pair<T, T> getMinMax(const std::map<std::string, T> &enum_map)
-{
-  T min, max;
-  if (enum_map.empty())
-  {
-    throw std::runtime_error("Trying to register an empty enum");
-  }
-
-  min = enum_map.begin()->second;
-  max = enum_map.begin()->second;
-
-  for (const auto &it : enum_map)
-  {
-    min = std::min(min, it.second);
-    max = std::max(min, it.second);
-  }
-
-  return std::make_pair(min, max);
-}
-
-
-
-#endif  // DDYNAMIC_RECONFIGURE_UTILS_H
+#endif

--- a/include/ddynamic_reconfigure/registered_param.h
+++ b/include/ddynamic_reconfigure/registered_param.h
@@ -36,6 +36,8 @@
 #include <type_traits>
 #include <boost/function.hpp>
 #include <dynamic_reconfigure/ParamDescription.h>
+#include <ddynamic_reconfigure/exception.h>
+
 namespace ddynamic_reconfigure
 {
 template <typename T>
@@ -183,9 +185,19 @@ public:
   }
   void updateValue(T new_value) override
   {
-    *variable_ = new_value;
     if (!callback_.empty())
-      callback_(new_value);
+    {
+      try
+      {
+	callback_(new_value);
+      }
+      catch (const CallbackException& e)
+      {
+	ROS_ERROR("Error in callback: %s", e.what());
+	return;
+      }
+    }
+    *variable_ = new_value;
   }
 
 protected:
@@ -216,7 +228,18 @@ public:
 
   void updateValue(T new_value) override
   {
-    callback_(new_value);
+    if (!callback_.empty())
+    {
+      try
+      {
+	callback_(new_value);
+      }
+      catch (const CallbackException& e)
+      {
+	ROS_ERROR("Error in callback: %s", e.what());
+	return;
+      }
+    }
     current_value_ = new_value;
   }
 

--- a/src/ddynamic_reconfigure.cpp
+++ b/src/ddynamic_reconfigure.cpp
@@ -94,7 +94,22 @@ void DDynamicReconfigure::registerVariable(const std::string &name, T *variable,
                                            const std::string &description, T min, T max,
                                            const std::string &group)
 {
+  const T initial_variable = *variable;
   attemptGetParam(node_handle_, name, *variable, *variable);
+  if (initial_variable != *variable && callback)
+  {
+    callPreUpdateCallback();
+    try
+    {
+      callback(*variable);
+    }
+    catch (const CallbackException &e)
+    {
+      ROS_ERROR("Error in callback: %s", e.what());
+      *variable = initial_variable;
+    }
+    callPostUpdateCallback();
+  }
   getRegisteredVector<T>().push_back(boost::make_unique<PointerRegisteredParam<T>>(
       name, description, min, max, variable, callback, std::map<std::string, T>(), "", group));
 }
@@ -107,9 +122,24 @@ void DDynamicReconfigure::registerEnumVariable(const std::string &name, T *varia
                                                const std::string &enum_description,
                                                const std::string &group)
 {
+  const T initial_variable = *variable;
+  attemptGetParam(node_handle_, name, *variable, *variable);
+  if (initial_variable != *variable && callback)
+  {
+    callPreUpdateCallback();
+    try
+    {
+      callback(*variable);
+    }
+    catch (const CallbackException& e)
+    {
+      ROS_WARN("Error in callback: %s", e.what());
+      *variable = initial_variable;
+    }
+    callPostUpdateCallback();
+  }
   T min, max;
   std::tie(min, max) = getMinMax(enum_dict);
-  attemptGetParam(node_handle_, name, *variable, *variable);
   getRegisteredVector<T>().push_back(boost::make_unique<PointerRegisteredParam<T>>(
       name, description, min, max, variable, callback, enum_dict, enum_description, group));
 }
@@ -120,7 +150,22 @@ void DDynamicReconfigure::registerVariable(const std::string &name, T current_va
                                            const std::string &description, T min, T max,
                                            const std::string &group)
 {
+  const T initial_value = current_value;
   attemptGetParam(node_handle_, name, current_value, current_value);
+  if (initial_value != current_value && callback)
+  {
+    callPreUpdateCallback();
+    try
+    {
+      callback(current_value);
+    }
+    catch (const CallbackException& e)
+    {
+      ROS_ERROR("Error in callback: %s", e.what());
+      current_value = initial_value;
+    }
+    callPostUpdateCallback();
+  }
   getRegisteredVector<T>().push_back(boost::make_unique<CallbackRegisteredParam<T>>(
       name, description, min, max, current_value, callback, std::map<std::string, T>(), "", group));
 }
@@ -134,9 +179,24 @@ void DDynamicReconfigure::registerEnumVariable(const std::string &name, T curren
                                                const std::string &enum_description,
                                                const std::string &group)
 {
+  const T initial_value = current_value;
   T min, max;
   std::tie(min, max) = getMinMax(enum_dict);
   attemptGetParam(node_handle_, name, current_value, current_value);
+  if (initial_value != current_value && callback)
+  {
+    callPreUpdateCallback();
+    try
+    {
+      callback(current_value);
+    }
+    catch (const CallbackException& e)
+    {
+      ROS_ERROR("Error in callback: %s", e.what());
+      current_value = initial_value;
+    }
+    callPostUpdateCallback();
+  }
   getRegisteredVector<T>().push_back(boost::make_unique<CallbackRegisteredParam<T>>(
       name, description, min, max, current_value, callback, enum_dict, enum_description, group));
 }
@@ -190,21 +250,7 @@ bool DDynamicReconfigure::setConfigCallback(dynamic_reconfigure::Reconfigure::Re
 {
   ROS_DEBUG_STREAM("Called config callback of ddynamic_reconfigure");
 
-  if (pre_update_callback_)
-  {
-    try
-    {
-      pre_update_callback_();
-    }
-    catch (std::exception &e)
-    {
-      ROS_WARN("Reconfigure pre update callback failed with exception %s: ", e.what());
-    }
-    catch (...)
-    {
-      ROS_WARN("Reconfigure pre update callback failed with unprintable exception.");
-    }
-  }
+  callPreUpdateCallback();
 
   updated_config_ = req.config;
   if (auto_update_)
@@ -257,21 +303,7 @@ bool DDynamicReconfigure::setConfigCallback(dynamic_reconfigure::Reconfigure::Re
      */
   // std::cerr<<req.config<<std::endl;
 
-  if (post_update_callback_)
-  {
-    try
-    {
-      post_update_callback_();
-    }
-    catch (std::exception &e)
-    {
-      ROS_WARN("Reconfigure post update callback failed with exception %s: ", e.what());
-    }
-    catch (...)
-    {
-      ROS_WARN("Reconfigure post update callback failed with unprintable exception.");
-    }
-  }
+  callPostUpdateCallback();
 
   dynamic_reconfigure::Config config_msg = generateConfig();
   update_pub_.publish(config_msg);
@@ -341,6 +373,44 @@ void DDynamicReconfigure::setPostUpdateCallback(const DDynamicReconfigure::UserC
 void DDynamicReconfigure::clearPostUpdateCallback()
 {
   post_update_callback_.clear();
+}
+
+void DDynamicReconfigure::callPreUpdateCallback()
+{
+  if (pre_update_callback_)
+  {
+    try
+    {
+      pre_update_callback_();
+    }
+    catch (const std::exception &e)
+    {
+      ROS_WARN("Reconfigure pre update callback failed with exception %s: ", e.what());
+    }
+    catch (...)
+    {
+      ROS_WARN("Reconfigure pre update callback failed with unprintable exception.");
+    }
+  }
+}
+
+void DDynamicReconfigure::callPostUpdateCallback()
+{
+  if (post_update_callback_)
+  {
+    try
+    {
+      post_update_callback_();
+    }
+    catch (const std::exception &e)
+    {
+      ROS_WARN("Reconfigure post update callback failed with exception %s: ", e.what());
+    }
+    catch (...)
+    {
+      ROS_WARN("Reconfigure post update callback failed with unprintable exception.");
+    }
+  }
 }
 
 void DDynamicReconfigure::RegisterVariable(double *variable, std::string id, double min, double max)

--- a/test/test_ddynamic_reconfigure.cpp
+++ b/test/test_ddynamic_reconfigure.cpp
@@ -315,6 +315,37 @@ TEST_F(DDynamicReconfigureTest, threadTest)
   ASSERT_EQ("bool_param", cfg_msg_->bools[0].name);
   ASSERT_EQ(bool_param, cfg_msg_->bools[0].value);
 }
+
+TEST_F(DDynamicReconfigureTest, callbackExceptionTest)
+{
+  ros::NodeHandle nh("~");
+  DDynamicReconfigure dd(nh);
+
+  int int_value = 0;
+
+  dd.registerVariable<int>(
+    "int_param", &int_value,
+    [](int new_value) { if (new_value < 0) { throw CallbackException("test"); } });
+  dd.PublishServicesTopics();
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+
+  dynamic_reconfigure::Reconfigure srv;
+  dynamic_reconfigure::IntParameter int_param;
+  int_param.name = "int_param";
+  int_param.value = 10;
+  srv.request.config.ints.push_back(int_param);
+
+  // Update request should be accepted because no exception is raised in the callback
+  EXPECT_EQ(int_value, 0);
+  EXPECT_TRUE(ros::service::call(nh.getNamespace() + "/set_parameters", srv));
+  EXPECT_EQ(int_value, 10);
+
+  // Update request should be rejected because exception is raised in the callback
+  int_param.value = -100;
+  EXPECT_TRUE(ros::service::call(nh.getNamespace() + "/set_parameters", srv));
+  EXPECT_EQ(int_value, 10);  // The value is unchanged
+}
 }
 
 


### PR DESCRIPTION
This PR introduces improvements in exception handling during the invocation of registered callback functions. The changes ensure that exceptions thrown within callbacks are managed appropriately, leading to the following benefits:

-  **Continuous Execution:** If an exception occurs during the execution of a callback, the overall program does not halt and continues to execute.
-  **Dynamic Reconfiguration Support:** By allowing specific exceptions to be thrown within the callback during requests to change values by the Dynamic Reconfigure client, the system can notify of a failure of the changing to the client and rollback any changes as needed.

In addition to the changes, I fixed an issue on that the `registerVariable` did not reflect the initial value set by dynamic reconfigure (stored in rosparam).

 The test case is also added.